### PR TITLE
AST now uses global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
 name = "curse_ast"
 version = "0.0.0"
 dependencies = [
+ "curse_interner",
  "curse_span",
 ]
 
@@ -214,8 +215,8 @@ dependencies = [
 name = "curse_parse"
 version = "0.0.0"
 dependencies = [
- "bumpalo",
  "curse_ast",
+ "curse_interner",
  "curse_span",
  "lalrpop",
  "lalrpop-util",

--- a/compiler/curse/src/main.rs
+++ b/compiler/curse/src/main.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 use bumpalo::Bump;
+use curse_interner::StringInterner;
 use miette::{Diagnostic, GraphicalReportHandler, NamedSource};
 use thiserror::Error;
 
@@ -41,13 +42,11 @@ impl<E: Diagnostic> Errors<E> {
 }
 
 fn main() {
-    curse_interner::init();
+    let mut interner = StringInterner::new();
 
     let input: &str = programs::REGIONS;
 
-    let ast_arena = Bump::new();
-    let strings = Bump::new();
-    let mut parser = curse_parse::Parser::new(&ast_arena, &strings);
+    let mut parser = curse_parse::Parser::new(&mut interner);
     let ast_program = parser.parse_program(input);
 
     if !parser.errors.is_empty() {
@@ -60,6 +59,8 @@ fn main() {
 
         return;
     }
+
+    curse_interner::replace(Some(interner));
 
     let hir_arena = Bump::new();
     let mut lowerer = curse_ast_lowering::Lowerer::new(&hir_arena);

--- a/compiler/curse_ast/Cargo.toml
+++ b/compiler/curse_ast/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 curse_span = { path = "../curse_span" }
+curse_interner = { path = "../curse_interner" }

--- a/compiler/curse_ast/src/ast/def.rs
+++ b/compiler/curse_ast/src/ast/def.rs
@@ -1,20 +1,21 @@
-use crate::ast::{tok, Closure, Iter, TypeRef};
+use crate::ast::{tok, Closure, Iter, Type};
 use crate::ast_struct;
+use curse_interner::Ident;
 use curse_span::HasSpan;
 
 ast_struct! {
     /// Example: `|K * V|`
     #[derive(Clone, Debug)]
-    pub struct GenericParams<'ast> {
+    pub struct GenericParams {
         open: tok::Pipe,
-        params: Vec<(tok::Literal<'ast>, tok::Star)>,
-        last: tok::Literal<'ast>,
+        params: Vec<(Ident, tok::Star)>,
+        last: Ident,
         close: tok::Pipe,
     }
 }
 
-impl<'ast> GenericParams<'ast> {
-    pub fn iter_params(&self) -> Iter<'_, tok::Literal<'ast>, tok::Star> {
+impl GenericParams {
+    pub fn iter_params(&self) -> Iter<'_, Ident, tok::Star> {
         Iter::new(self.params.iter(), Some(&self.last))
     }
 }
@@ -22,58 +23,58 @@ impl<'ast> GenericParams<'ast> {
 ast_struct! {
     /// Example: `fn add = |x, y| x + y`
     #[derive(Clone, Debug)]
-    pub struct FunctionDef<'ast> {
+    pub struct FunctionDef {
         pub fn_: tok::Fn,
-        pub ident: tok::Literal<'ast>,
-        pub function: Closure<'ast>,
+        pub ident: Ident,
+        pub function: Closure,
     }
 }
 
 ast_struct! {
     /// Example: `T: T -> T`
     #[derive(Clone, Debug)]
-    pub struct ExplicitTypes<'ast> {
-        pub generic_params: Option<GenericParams<'ast>>,
+    pub struct ExplicitTypes {
+        pub generic_params: Option<GenericParams>,
         pub colon: tok::Colon,
-        pub ty: TypeRef<'ast>,
+        pub ty: Type,
     }
 }
 
 ast_struct! {
     /// Example: `struct Id I32`
     #[derive(Clone, Debug)]
-    pub struct StructDef<'ast> {
+    pub struct StructDef {
         pub struct_: tok::Struct,
-        pub ident: tok::Literal<'ast>,
-        pub generic_params: Option<GenericParams<'ast>>,
-        pub ty: TypeRef<'ast>,
+        pub ident: Ident,
+        pub generic_params: Option<GenericParams>,
+        pub ty: Type,
     }
 }
 
 ast_struct! {
     /// Example: `choice Option |T| { Some T, None {} }`
     #[derive(Clone, Debug)]
-    pub struct ChoiceDef<'ast> {
+    pub struct ChoiceDef {
         pub choice: tok::Choice,
-        pub ident: tok::Literal<'ast>,
-        pub generic_params: Option<GenericParams<'ast>>,
-        pub variants: Variants<'ast>,
+        pub ident: Ident,
+        pub generic_params: Option<GenericParams>,
+        pub variants: Variants,
     }
 }
 
 ast_struct! {
     /// Example: `{ Some T, None {} }`
     #[derive(Debug, Clone)]
-    pub struct Variants<'ast> {
+    pub struct Variants {
         lbrace: tok::LBrace,
-        variants: Vec<(VariantDef<'ast>, tok::Comma)>,
-        last: Option<VariantDef<'ast>>,
+        variants: Vec<(VariantDef, tok::Comma)>,
+        last: Option<VariantDef>,
         rbrace: tok::RBrace,
     }
 }
 
-impl<'ast> Variants<'ast> {
-    pub fn iter_variants(&self) -> Iter<'_, VariantDef<'ast>, tok::Comma> {
+impl Variants {
+    pub fn iter_variants(&self) -> Iter<'_, VariantDef, tok::Comma> {
         Iter::new(self.variants.iter(), self.last.as_ref())
     }
 }
@@ -81,13 +82,13 @@ impl<'ast> Variants<'ast> {
 ast_struct! {
     /// Example: `Some T`
     #[derive(Clone, Debug)]
-    pub struct VariantDef<'ast> {
-        pub ident: tok::Literal<'ast>,
-        pub ty: TypeRef<'ast>,
+    pub struct VariantDef {
+        pub ident: Ident,
+        pub ty: Type,
     }
 }
 
-impl HasSpan for GenericParams<'_> {
+impl HasSpan for GenericParams {
     fn start(&self) -> u32 {
         self.open.start()
     }
@@ -97,7 +98,7 @@ impl HasSpan for GenericParams<'_> {
     }
 }
 
-impl HasSpan for FunctionDef<'_> {
+impl HasSpan for FunctionDef {
     fn start(&self) -> u32 {
         self.fn_.start()
     }
@@ -107,7 +108,7 @@ impl HasSpan for FunctionDef<'_> {
     }
 }
 
-impl HasSpan for StructDef<'_> {
+impl HasSpan for StructDef {
     fn start(&self) -> u32 {
         self.struct_.start()
     }
@@ -117,7 +118,7 @@ impl HasSpan for StructDef<'_> {
     }
 }
 
-impl HasSpan for ChoiceDef<'_> {
+impl HasSpan for ChoiceDef {
     fn start(&self) -> u32 {
         self.choice.start()
     }
@@ -127,7 +128,7 @@ impl HasSpan for ChoiceDef<'_> {
     }
 }
 
-impl HasSpan for Variants<'_> {
+impl HasSpan for Variants {
     fn start(&self) -> u32 {
         self.lbrace.start()
     }
@@ -137,7 +138,7 @@ impl HasSpan for Variants<'_> {
     }
 }
 
-impl HasSpan for VariantDef<'_> {
+impl HasSpan for VariantDef {
     fn start(&self) -> u32 {
         self.ident.start()
     }

--- a/compiler/curse_ast/src/ast/expr/closure.rs
+++ b/compiler/curse_ast/src/ast/expr/closure.rs
@@ -1,22 +1,22 @@
-use crate::ast::{tok, Expr, Iter, Pat, TypeRef};
+use crate::ast::{tok, Expr, Iter, Pat, Type};
 use crate::ast_struct;
 use curse_span::{HasSpan, Span};
 
 #[derive(Clone, Debug)]
-pub enum Closure<'ast> {
-    NonPiecewise(Arm<'ast>),
+pub enum Closure {
+    NonPiecewise(Arm),
     Piecewise(
         tok::LParen,
         // Parser will only produce vecs with len >= 1
-        Vec<(Arm<'ast>, tok::Comma)>,
-        Option<Arm<'ast>>,
+        Vec<(Arm, tok::Comma)>,
+        Option<Arm>,
         tok::RParen,
     ),
     Empty(tok::LParen, tok::RParen),
 }
 
-impl<'ast> Closure<'ast> {
-    pub fn iter_arms(&self) -> Iter<'_, Arm<'ast>, tok::Comma> {
+impl Closure {
+    pub fn iter_arms(&self) -> Iter<'_, Arm, tok::Comma> {
         let (arms, last) = match self {
             Closure::NonPiecewise(arm) => (&[] as _, Some(arm)),
             Closure::Piecewise(_, arms, last, _) => (arms.as_slice(), last.as_ref()),
@@ -27,7 +27,7 @@ impl<'ast> Closure<'ast> {
     }
 }
 
-impl HasSpan for Closure<'_> {
+impl HasSpan for Closure {
     fn start(&self) -> u32 {
         match self {
             Closure::NonPiecewise(arm) => arm.start(),
@@ -55,24 +55,24 @@ impl HasSpan for Closure<'_> {
 
 ast_struct! {
     #[derive(Clone, Debug)]
-    pub struct Arm<'ast> {
+    pub struct Arm {
         pub open: tok::Pipe,
         // There should only be up to 2 params,
         // but more shouldn't make the parser fail.
-        pub params: Vec<(Param<'ast>, tok::Comma)>,
-        pub last: Option<Param<'ast>>,
+        pub params: Vec<(Param, tok::Comma)>,
+        pub last: Option<Param>,
         pub close: tok::Pipe,
-        pub body: &'ast Expr<'ast>,
+        pub body: Expr,
     }
 }
 
-impl<'ast> Arm<'ast> {
-    pub fn iter_params(&self) -> Iter<'_, Param<'ast>, tok::Comma> {
+impl Arm {
+    pub fn iter_params(&self) -> Iter<'_, Param, tok::Comma> {
         Iter::new(self.params.iter(), self.last.as_ref())
     }
 }
 
-impl HasSpan for Arm<'_> {
+impl HasSpan for Arm {
     fn start(&self) -> u32 {
         self.open.start()
     }
@@ -84,8 +84,8 @@ impl HasSpan for Arm<'_> {
 
 ast_struct! {
     #[derive(Clone, Debug)]
-    pub struct Param<'ast> {
-        pub pat: &'ast Pat<'ast>,
-        pub ascription: Option<(tok::Colon, TypeRef<'ast>)>,
+    pub struct Param {
+        pub pat: Pat,
+        pub ascription: Option<(tok::Colon, Type)>,
     }
 }

--- a/compiler/curse_ast/src/ast/mod.rs
+++ b/compiler/curse_ast/src/ast/mod.rs
@@ -12,12 +12,12 @@ mod ty;
 pub use def::{
     ChoiceDef, ExplicitTypes, FunctionDef, GenericParams, StructDef, VariantDef, Variants,
 };
-pub use expr::{Appl, Arm, Closure, Expr, ExprRef, Param, Paren, Region, RegionKind, Symbol};
-pub use pat::{Pat, PatRef};
+pub use expr::{Appl, Arm, Closure, Expr, Param, Paren, Region, RegionKind, Symbol};
+pub use pat::Pat;
 pub use program::Program;
 pub use record::{Field, Record};
 pub use shared::{Constructor, Iter, Lit, Path};
-pub use ty::{GenericArgs, NamedType, Type, TypeRef};
+pub use ty::{GenericArgs, NamedType, Type};
 
 /// Macro to automatically derive a `new` constructor.
 #[macro_export]
@@ -35,6 +35,25 @@ macro_rules! ast_struct {
 
         impl<$($generics),*> $name <$($generics),*> {
             pub fn new($($field : $ty),*) -> $name <$($generics),*> {
+                $name { $($field),* }
+            }
+        }
+    };
+
+
+(
+    $(#[$attrs:meta])*
+    $vis:vis struct $name:ident {
+        $($field_vis:vis $field:ident : $ty:ty,)*
+    }
+) => {
+        $(#[$attrs])*
+        $vis struct $name {
+            $($field_vis $field : $ty,)*
+        }
+
+        impl $name {
+            pub fn new($($field : $ty),*) -> $name {
                 $name { $($field),* }
             }
         }

--- a/compiler/curse_ast/src/ast/pat.rs
+++ b/compiler/curse_ast/src/ast/pat.rs
@@ -2,15 +2,13 @@ use crate::ast::{Constructor, Lit, Record};
 use curse_span::{HasSpan, Span};
 
 #[derive(Clone, Debug)]
-pub enum Pat<'ast> {
-    Lit(Lit<'ast>),
-    Record(Record<'ast, PatRef<'ast>>),
-    Constructor(Constructor<'ast, Self>),
+pub enum Pat {
+    Lit(Lit),
+    Record(Box<Record<Self>>),
+    Constructor(Box<Constructor<Self>>),
 }
 
-pub type PatRef<'ast> = &'ast Pat<'ast>;
-
-impl HasSpan for Pat<'_> {
+impl HasSpan for Pat {
     fn start(&self) -> u32 {
         match self {
             Pat::Lit(lit) => lit.start(),

--- a/compiler/curse_ast/src/ast/program.rs
+++ b/compiler/curse_ast/src/ast/program.rs
@@ -1,24 +1,24 @@
 use crate::ast::{ChoiceDef, FunctionDef, StructDef};
 
 #[derive(Clone, Debug, Default)]
-pub struct Program<'ast> {
-    pub function_defs: Vec<FunctionDef<'ast>>,
-    pub struct_defs: Vec<StructDef<'ast>>,
-    pub choice_defs: Vec<ChoiceDef<'ast>>,
+pub struct Program {
+    pub function_defs: Vec<FunctionDef>,
+    pub struct_defs: Vec<StructDef>,
+    pub choice_defs: Vec<ChoiceDef>,
 }
 
-impl<'ast> Program<'ast> {
-    pub fn with_function_def(mut self, function_def: FunctionDef<'ast>) -> Self {
+impl Program {
+    pub fn with_function_def(mut self, function_def: FunctionDef) -> Self {
         self.function_defs.push(function_def);
         self
     }
 
-    pub fn with_struct_def(mut self, struct_def: StructDef<'ast>) -> Self {
+    pub fn with_struct_def(mut self, struct_def: StructDef) -> Self {
         self.struct_defs.push(struct_def);
         self
     }
 
-    pub fn with_choice_def(mut self, choice_def: ChoiceDef<'ast>) -> Self {
+    pub fn with_choice_def(mut self, choice_def: ChoiceDef) -> Self {
         self.choice_defs.push(choice_def);
         self
     }

--- a/compiler/curse_ast/src/ast/record.rs
+++ b/compiler/curse_ast/src/ast/record.rs
@@ -1,32 +1,33 @@
 use crate::ast::{tok, Iter};
 use crate::ast_struct;
 use curse_span::HasSpan;
+use curse_interner::Ident;
 
 ast_struct! {
     #[derive(Clone, Debug)]
-    pub struct Record<'ast, T> {
+    pub struct Record<T> {
         pub lbrace: tok::LBrace,
-        pub fields: Vec<(Field<'ast, T>, tok::Comma)>,
-        pub trailing: Option<Field<'ast, T>>,
+        pub fields: Vec<(Field<T>, tok::Comma)>,
+        pub trailing: Option<Field<T>>,
         pub rbrace: tok::RBrace,
     }
 }
 
 ast_struct! {
     #[derive(Clone, Debug)]
-    pub struct Field<'ast, T> {
-        pub ident: tok::Literal<'ast>,
+    pub struct Field<T> {
+        pub ident: Ident,
         pub value: Option<(tok::Colon, T)>,
     }
 }
 
-impl<'ast, T> Record<'ast, T> {
-    pub fn iter_fields(&self) -> Iter<'_, Field<'ast, T>, tok::Comma> {
+impl<T> Record<T> {
+    pub fn iter_fields(&self) -> Iter<'_, Field<T>, tok::Comma> {
         Iter::new(self.fields.iter(), self.trailing.as_ref())
     }
 }
 
-impl<T> HasSpan for Record<'_, T> {
+impl<T> HasSpan for Record<T> {
     fn start(&self) -> u32 {
         self.lbrace.start()
     }
@@ -36,7 +37,7 @@ impl<T> HasSpan for Record<'_, T> {
     }
 }
 
-impl<T: HasSpan> HasSpan for Field<'_, T> {
+impl<T: HasSpan> HasSpan for Field<T> {
     fn start(&self) -> u32 {
         self.ident.start()
     }

--- a/compiler/curse_ast/src/ast/ty/mod.rs
+++ b/compiler/curse_ast/src/ast/ty/mod.rs
@@ -5,17 +5,15 @@ mod named;
 pub use named::{GenericArgs, NamedType};
 
 #[derive(Clone, Debug)]
-pub enum Type<'ast> {
-    Named(NamedType<'ast>),
+pub enum Type {
+    Named(Box<NamedType>),
     // Failing to specify the type of a field in a record should be reported during ast lowering,
     // not during parsing, so we allow for a type to be omitted in this representation.
-    Record(Record<'ast, TypeRef<'ast>>),
+    Record(Box<Record<Self>>),
     Error,
 }
 
-pub type TypeRef<'ast> = &'ast Type<'ast>;
-
-impl HasSpan for Type<'_> {
+impl HasSpan for Type {
     fn start(&self) -> u32 {
         match self {
             Type::Named(named) => named.start(),

--- a/compiler/curse_ast/src/ast/ty/named.rs
+++ b/compiler/curse_ast/src/ast/ty/named.rs
@@ -1,41 +1,36 @@
-use crate::ast::{tok, Iter, Path, Type, TypeRef};
+use crate::ast::{tok, Iter, Path, Type};
 use crate::ast_struct;
 use curse_span::{HasSpan, Span};
 
 ast_struct! {
     /// A named type, e.g. `std::vec::Vec T`
     #[derive(Clone, Debug)]
-    pub struct NamedType<'ast> {
-        pub path: Path<'ast>,
-        pub generic_args: Option<GenericArgs<'ast>>,
+    pub struct NamedType {
+        pub path: Path,
+        pub generic_args: Option<GenericArgs>,
     }
 }
 
 #[derive(Clone, Debug)]
-pub enum GenericArgs<'ast> {
+pub enum GenericArgs {
     /// Example: `Vec I32`
-    Single(TypeRef<'ast>),
+    Single(Type),
     /// Example: `Result (I32 * Error)`
-    CartesianProduct(
-        tok::LParen,
-        Vec<(Type<'ast>, tok::Star)>,
-        TypeRef<'ast>,
-        tok::RParen,
-    ),
+    CartesianProduct(tok::LParen, Vec<(Type, tok::Star)>, Type, tok::RParen),
 }
 
-impl<'ast> GenericArgs<'ast> {
-    pub fn iter_args(&self) -> Iter<'_, Type<'ast>, tok::Star> {
+impl GenericArgs {
+    pub fn iter_args(&self) -> Iter<'_, Type, tok::Star> {
         let (slice, last) = match self {
-            GenericArgs::Single(last) => (&[] as _, Some(*last)),
-            GenericArgs::CartesianProduct(_, vec, last, _) => (vec.as_slice(), Some(*last)),
+            GenericArgs::Single(last) => (&[] as _, Some(last)),
+            GenericArgs::CartesianProduct(_, vec, last, _) => (vec.as_slice(), Some(last)),
         };
 
         Iter::new(slice.iter(), last)
     }
 }
 
-impl HasSpan for NamedType<'_> {
+impl HasSpan for NamedType {
     fn start(&self) -> u32 {
         self.path.start()
     }
@@ -49,7 +44,7 @@ impl HasSpan for NamedType<'_> {
     }
 }
 
-impl HasSpan for GenericArgs<'_> {
+impl HasSpan for GenericArgs {
     fn start(&self) -> u32 {
         match self {
             GenericArgs::Single(ty) => ty.start(),

--- a/compiler/curse_parse/Cargo.toml
+++ b/compiler/curse_parse/Cargo.toml
@@ -10,8 +10,8 @@ lalrpop = "0.20.0"
 lalrpop-util = "0.20.0"
 curse_ast = { path = "../curse_ast" }
 curse_span = { path = "../curse_span" }
+curse_interner = { path = "../curse_interner" }
 logos = "0.13"
 miette = "5.9.0"
-bumpalo = "3.13.0"
 thiserror = "1.0.39"
 unicode-ident = "1.0.9"

--- a/compiler/curse_parse/src/error.rs
+++ b/compiler/curse_parse/src/error.rs
@@ -56,7 +56,7 @@ pub enum Error {
     InvalidInteger(#[label("This isn't a valid integer")] SourceSpan),
 }
 
-type LalrParseError<'ast> = ParseError<usize, Token<'ast>, LexError>;
+type LalrParseError<'input> = ParseError<usize, Token<'input>, LexError>;
 
 impl From<LalrParseError<'_>> for Error {
     fn from(value: LalrParseError<'_>) -> Self {

--- a/compiler/curse_parse/src/grammar.lalrpop
+++ b/compiler/curse_parse/src/grammar.lalrpop
@@ -1,12 +1,14 @@
 use crate::{lexer::*, Parser};
 use curse_ast::ast::{
-    tok, Appl, Arm, ChoiceDef, Closure, Constructor, ExplicitTypes, Expr, Field, FunctionDef,
+    tok, Appl, Arm, ChoiceDef, Closure, Constructor, Expr, Field, FunctionDef,
     GenericArgs, GenericParams, Lit, NamedType, Param, Paren, Path, Pat, Program, Record, StructDef, 
     Symbol, Type, VariantDef, Variants,
     Region, RegionKind,
 };
+use curse_interner::Ident;
+use curse_span::HasSpan;
 
-grammar<'ast>(parser: &mut Parser<'ast>);
+grammar<'input>(parser: &mut Parser<'_>);
 
 extern {
     type Location = usize;
@@ -15,13 +17,13 @@ extern {
     // Any changes here must also be reflected in:
     // - curse_parse/src/lexer.rs
     // - curse_ast/src/tok.rs
-    enum Token<'ast> {
+    enum Token<'input> {
         // In the grammar, if we specify the string on the lhs,
         // it means that we're waiting for the lexer to
         // give us the rhs.
-        "ident literal" => Token::Ident(<tok::Literal<'ast>>),
-        "type ident literal" => Token::TypeIdent(<tok::Literal<'ast>>),
-        "integer literal" => Token::Integer(<tok::Literal<'ast>>),
+        "ident literal" => Token::Ident(<tok::Literal<'input>>),
+        "type ident literal" => Token::TypeIdent(<tok::Literal<'input>>),
+        "integer literal" => Token::Integer(<tok::Literal<'input>>),
         ":" => Token::Colon(<tok::Colon>),
         "::" => Token::ColonColon(<tok::ColonColon>),
         "," => Token::Comma(<tok::Comma>),
@@ -58,14 +60,14 @@ extern {
 
 /// === Term Aliases ===
 
-Ident: tok::Literal<'ast> = "ident literal";
-TypeIdent: tok::Literal<'ast> = "type ident literal";
-Integer: tok::Literal<'ast> = "integer literal";
+Ident: Ident = "ident literal" => Ident::new_in(<>.as_ref(), <>.span(), parser.interner);
+TypeIdent: Ident = "type ident literal" => Ident::new_in(<>.as_ref(), <>.span(), parser.interner);
+Integer: Ident = "integer literal" => Ident::new_in(<>.as_ref(), <>.span(), parser.interner);
 
 
 /// === Program ===
 
-pub Program: Program<'ast> = {
+pub Program: Program = {
     FunctionDef => Program::default().with_function_def(<>),
     ChoiceDef => Program::default().with_choice_def(<>),
     StructDef => Program::default().with_struct_def(<>),
@@ -82,101 +84,100 @@ pub Program: Program<'ast> = {
 
 /// === Definitions ===
 
-GenericParams: GenericParams<'ast> = {
+GenericParams: GenericParams = {
     "|" (TypeIdent "*")* TypeIdent "|" => GenericParams::new(<>),
 };
 
-ExplicitTypes: ExplicitTypes<'ast> = {
-    GenericParams? ":" Ref<Type> => ExplicitTypes::new(<>),
-}
+// ExplicitTypes: ExplicitTypes = {
+//     GenericParams? ":" Ref<Type> => ExplicitTypes::new(<>),
+// }
 
-FunctionDef: FunctionDef<'ast> = {
+FunctionDef: FunctionDef = {
     "fn" Ident Closure => FunctionDef::new(<>),
     // "fn" Ident ExplicitTypes? Closure => FunctionDef::new(<>),
 };
 
-StructDef: StructDef<'ast> = {
-    "struct" TypeIdent GenericParams? Ref<Type> => StructDef::new(<>),
+StructDef: StructDef = {
+    "struct" TypeIdent GenericParams? Type => StructDef::new(<>),
 };
 
-ChoiceDef: ChoiceDef<'ast> = {
+ChoiceDef: ChoiceDef = {
     "choice" TypeIdent GenericParams? Variants => ChoiceDef::new(<>),
 };
 
-Variants: Variants<'ast> = {
+Variants: Variants = {
     "{" (VariantDef ",")* VariantDef? "}" => Variants::new(<>),
 }
 
-VariantDef: VariantDef<'ast> = {
-    TypeIdent Ref<Type> => VariantDef::new(<>),
+VariantDef: VariantDef = {
+    TypeIdent Type => VariantDef::new(<>),
 };
 
 
 /// === Record ===
 
-Record<T>: Record<'ast, T> = {
+Record<T>: Record<T> = {
     "{" (Field<T> ",")* Field<T>? "}" => Record::new(<>),
 };
 
-Field<T>: Field<'ast, T> = {
+Field<T>: Field<T> = {
     Ident (":" T)? => Field::new(<>),
 };
 
-// Get an arena-allocated reference
-Ref<T>: &'ast T = {
-    T => parser.bump.alloc(<>),
+Box<T>: Box<T> = {
+    T => Box::new(<>),
 }
 
 
 /// === Types ===
 
-Type: Type<'ast> = {
-    NamedType => Type::Named(<>),
-    Record<Ref<Type>> => Type::Record(<>),
+Type: Type = {
+    Box<NamedType> => Type::Named(<>),
+    Box<Record<Type>> => Type::Record(<>),
     ! => {
         parser.errors.push(<>.error.into());
         Type::Error
     }
 };
 
-GenericArgs: GenericArgs<'ast> = {
-    Ref<Type> => GenericArgs::Single(<>),
-    "(" (Type "*")* Ref<Type> ")" => GenericArgs::CartesianProduct(<>),
+GenericArgs: GenericArgs = {
+    Type => GenericArgs::Single(<>),
+    "(" (Type "*")* Type ")" => GenericArgs::CartesianProduct(<>),
 };
 
-NamedType: NamedType<'ast> = {
+NamedType: NamedType = {
     TypePath GenericArgs? => NamedType::new(<>),
 };
 
 
 /// === Patterns ===
 
-Pat: Pat<'ast> = {
+Pat: Pat = {
     Lit => Pat::Lit(<>),
-    Record<Ref<Pat>> => Pat::Record(<>),
-    Constructor<Pat> => Pat::Constructor(<>),
+    Box<Record<Pat>> => Pat::Record(<>),
+    Box<Constructor<Pat>> => Pat::Constructor(<>),
 };
 
 
 /// === Shared ===
 
-Lit: Lit<'ast> = {
+Lit: Lit = {
     Integer => Lit::Integer(<>),
     Ident => Lit::Ident(<>),
     "true" => Lit::True(<>),
     "false" => Lit::False(<>),
 };
 
-Path: Path<'ast> = {
+Path: Path = {
     (Ident "::")* Ident => Path::new(<>),
 };
 
-TypePath: Path<'ast> = {
+TypePath: Path = {
     (Ident "::")* TypeIdent => Path::new(<>),
 };
 
-Constructor<T>: Constructor<'ast, T> = {
-    TypePath ("::" TypeIdent)? Ref<T> => Constructor::new(<>),
+Constructor<T>: Constructor<T> = {
+    TypePath ("::" TypeIdent)? T => Constructor::new(<>),
 };
 
 
@@ -198,11 +199,11 @@ Symbol: Symbol = {
     ">=" => Symbol::Ge(<>),
 };
 
-ClosureNonpiecewise: Closure<'ast> = {
+ClosureNonpiecewise: Closure = {
     Arm => Closure::NonPiecewise(<>),
 };
 
-ClosurePiecewise: Closure<'ast> = {
+ClosurePiecewise: Closure = {
     "(" ")" => Closure::Empty(<>),
     "(" (Arm ",")+ Arm? ")" => Closure::Piecewise(<>),
 };
@@ -212,20 +213,20 @@ Closure = {
     ClosurePiecewise,
 };
 
-Arm: Arm<'ast> = {
-    "|" (Param ",")* Param? "|" Ref<EndExpr> => Arm::new(<>),
+Arm: Arm = {
+    "|" (Param ",")* Param? "|" EndExpr => Arm::new(<>),
 };
 
-Param: Param<'ast> = {
-    Ref<Pat> (":" Ref<Type>)? => Param::new(<>),
+Param: Param = {
+    Pat (":" Type)? => Param::new(<>),
 };
 
-Appl<Rhs>: Appl<'ast> = {
-    Ref<Expr> Ref<Term> Ref<Rhs> => Appl::new(<>),
+Appl<Rhs>: Appl = {
+    Expr Term Rhs => Appl::new(<>),
 };
 
-Region: Region<'ast> = {
-    RegionKind Ref<Pat> "{" Ref<EndExpr> "}" => Region::new(<>),
+Region: Region = {
+    RegionKind Pat "{" EndExpr "}" => Region::new(<>),
 };
 
 RegionKind: RegionKind = {
@@ -234,17 +235,17 @@ RegionKind: RegionKind = {
     "ref" "mut" => RegionKind::RefMut(<>),
 }
 
-Paren: Paren<'ast> = {
-    "(" Ref<EndExpr> ")" => Paren::new(<>),
+Paren: Paren = {
+    "(" EndExpr ")" => Paren::new(<>),
 };
 
-Term: Expr<'ast> = {
-    Paren => Expr::Paren(<>),
+Term: Expr = {
+    Box<Paren> => Expr::Paren(<>),
     Symbol => Expr::Symbol(<>),
     Lit => Expr::Lit(<>),
-    Record<Ref<EndExpr>> => Expr::Record(<>),
-    Ref<ClosurePiecewise> => Expr::Closure(<>),
-    Region => Expr::Region(<>),
+    Box<Record<EndExpr>> => Expr::Record(<>),
+    Box<ClosurePiecewise> => Expr::Closure(<>),
+    Box<Region> => Expr::Region(<>),
     ! => {
         parser.errors.push(<>.error.into());
         Expr::Error
@@ -253,16 +254,16 @@ Term: Expr<'ast> = {
 
 EndTerm = {
     Term,
-    Constructor<EndExpr> => Expr::Constructor(<>),
-    Ref<ClosureNonpiecewise> => Expr::Closure(<>),
+    Box<Constructor<EndExpr>> => Expr::Constructor(<>),
+    Box<ClosureNonpiecewise> => Expr::Closure(<>),
 };
 
 Expr = {
     Term,
-    Appl<Term> => Expr::Appl(<>),
+    Box<Appl<Term>> => Expr::Appl(<>),
 };
 
 pub EndExpr = {
     EndTerm,
-    Appl<EndTerm> => Expr::Appl(<>),
+    Box<Appl<EndTerm>> => Expr::Appl(<>),
 };

--- a/compiler/curse_parse/src/lexer.rs
+++ b/compiler/curse_parse/src/lexer.rs
@@ -1,4 +1,3 @@
-use bumpalo::Bump;
 use curse_ast::ast::tok;
 use curse_span::{HasSpan, Span};
 use logos::Logos;
@@ -89,22 +88,20 @@ macro_rules! declare_tokens {
         }
 
         #[derive(Clone, Debug)]
-        pub struct Lexer<'ast, 'input> {
+        pub struct Lexer<'input> {
             lex: logos::Lexer<'input, LogosToken>,
-            strings: &'ast Bump,
         }
 
-        impl<'ast, 'input> Lexer<'ast, 'input> {
-            pub fn new(strings: &'ast Bump, input: &'input str) -> Self {
+        impl<'input> Lexer<'input> {
+            pub fn new(input: &'input str) -> Self {
                 Lexer {
                     lex: Logos::lexer(input),
-                    strings,
                 }
             }
         }
 
-        impl<'ast, 'input> Iterator for Lexer<'ast, 'input> {
-            type Item = Result<(usize, Token<'ast>, usize), LexError>;
+        impl<'input> Iterator for Lexer<'input> {
+            type Item = Result<(usize, Token<'input>, usize), LexError>;
 
             fn next(&mut self) -> Option<Self::Item> {
                 let token = self.lex.next()?;
@@ -114,15 +111,15 @@ macro_rules! declare_tokens {
                     Ok(LogosToken::Word(word)) => match word {
                         Word::Ident => Token::Ident(tok::Literal {
                             location: span.start,
-                            literal: self.strings.alloc_str(self.lex.slice()),
+                            literal: self.lex.slice(),
                         }),
                         Word::TypeIdent => Token::TypeIdent(tok::Literal {
                             location: span.start,
-                            literal: self.strings.alloc_str(self.lex.slice()),
+                            literal: self.lex.slice(),
                         }),
                         Word::Integer => Token::Integer(tok::Literal {
                             location: span.start,
-                            literal: self.strings.alloc_str(self.lex.slice()),
+                            literal: self.lex.slice(),
                         }),
                         Word::InvalidIdent => return Some(Err(LexError::InvalidIdent(span))),
                         Word::InvalidInteger => return Some(Err(LexError::InvalidInteger(span))),

--- a/compiler/curse_parse/src/lib.rs
+++ b/compiler/curse_parse/src/lib.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 
-use bumpalo::Bump;
 use curse_ast::ast;
+use curse_interner::StringInterner;
 use lalrpop_util::lalrpop_mod;
 
 mod error;
@@ -15,30 +15,28 @@ lalrpop_mod!(
     grammar
 );
 
-pub struct Parser<'ast> {
-    pub bump: &'ast Bump,
-    pub strings: &'ast Bump,
+pub struct Parser<'intern> {
+    pub interner: &'intern mut StringInterner,
     pub errors: Vec<Error>,
 }
 
-impl<'ast> Parser<'ast> {
-    pub fn new(bump: &'ast Bump, strings: &'ast Bump) -> Self {
+impl<'intern> Parser<'intern> {
+    pub fn new(interner: &'intern mut StringInterner) -> Self {
         Parser {
-            bump,
-            strings,
+            interner,
             errors: Vec::with_capacity(0),
         }
     }
 
-    pub fn parse_program(&mut self, input: &str) -> ast::Program<'ast> {
+    pub fn parse_program(&mut self, input: &str) -> ast::Program {
         grammar::ProgramParser::new()
-            .parse(self, Lexer::new(self.strings, input))
+            .parse(self, Lexer::new(input))
             .expect("`Program` rule recovers from all errors")
     }
 
-    pub fn parse_expr(&mut self, input: &str) -> ast::Expr<'ast> {
+    pub fn parse_expr(&mut self, input: &str) -> ast::Expr {
         grammar::EndExprParser::new()
-            .parse(self, Lexer::new(self.strings, input))
+            .parse(self, Lexer::new(input))
             .expect("`EndExpr` rule recovers from all errors")
     }
 }

--- a/compiler/curse_span/src/lib.rs
+++ b/compiler/curse_span/src/lib.rs
@@ -40,6 +40,20 @@ pub trait HasSpan {
     }
 }
 
+impl HasSpan for Span {
+    fn start(&self) -> u32 {
+        self.start
+    }
+
+    fn end(&self) -> u32 {
+        self.end
+    }
+
+    fn span(&self) -> Span {
+        *self
+    }
+}
+
 impl<T: HasSpan> HasSpan for &T {
     fn start(&self) -> u32 {
         (*self).start()


### PR DESCRIPTION
Fixes https://github.com/QnnOkabayashi/curse-lang/issues/6

This solves the memory leak problem in the AST by simply removing all arena complexity and just using the global allocator. Though we may want to revisit arenas for the AST later, a small (and likely unnoticeable) performance hit is worth it for decreased complexity and avoiding leaks.

Since arenas are gone from the AST, there were also some changes with string storage in the AST:
* The lexer still parses tokens with lifetimes, but they reference the input text.
* The parser interns any `&str` in the tokens

As a result, the AST now depends on `curse_interner`. One small optimization I made is that the parser itself now just holds a mutable reference to a `StringInterner`, meaning we can completely avoid having to lock and unlock it each time. If we ever get to a point where we want to parse in parallel, this will have to change. But for now it seemed like an okay idea.

Also note that in recursive types like `Expr` and `Type`, I've moved around the indirection to mostly appear directly within the enums so that they stay small, e.g. `Expr` has `Appl(Box<Appl>)`. This means that `Expr` and `Type` are each small values (16 bytes I think).