### PR TITLE
Fix struct def and piecewise function lowering

### DIFF
--- a/compiler/curse_ast/src/ast/shared.rs
+++ b/compiler/curse_ast/src/ast/shared.rs
@@ -26,16 +26,13 @@ impl<'a, T, D> Iterator for Iter<'a, T, D> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.last.is_none() {
-            (0, Some(0))
-        } else {
-            let (lo, hi) = self.parts.size_hint();
-            // hi <= isize::MAX since it comes from a slice,
-            // which must point to an allocation, which cannot be
-            // > isize::MAX
-            // Therefore, it follows that hi + 1 < usize::MAX
-            (lo + 1, hi.map(|hi| hi + 1))
-        }
+        let last = self.last.is_some() as usize;
+        let (lo, hi) = self.parts.size_hint();
+        // hi <= isize::MAX since it comes from a slice,
+        // which must point to an allocation, which cannot be
+        // > isize::MAX
+        // Therefore, it follows that hi + 1 < usize::MAX
+        (lo + last, Some(hi.unwrap() + last))
     }
 }
 

--- a/compiler/curse_hir/src/hir/map.rs
+++ b/compiler/curse_hir/src/hir/map.rs
@@ -20,9 +20,7 @@ impl<T> Default for Map<'_, T> {
 // Manual impl because `#[derive(Clone)]` has `T: Clone` bound.
 impl<T> Clone for Map<'_, T> {
     fn clone(&self) -> Self {
-        Map {
-            entries: self.entries,
-        }
+        *self
     }
 }
 

--- a/compiler/curse_interpreter/src/main.rs
+++ b/compiler/curse_interpreter/src/main.rs
@@ -9,17 +9,15 @@ mod evaluation;
 mod value;
 
 pub fn main() -> io::Result<()> {
-    let mut interner = StringInterner::new();
-    curse_interner::init();
-
-    let hir_arena = Bump::new();
-    let mut parser = curse_parse::Parser::new(&mut interner);
-
-    let mut args = std::env::args();
-    args.next();
-
-    let file_name = args.next().expect("usage: ./curse_interpreter <filename>");
+    let args = std::env::args();
+    let file_name = args
+        .skip(1)
+        .next()
+        .expect("usage: ./curse_interpreter <filename>");
     let file = std::fs::read_to_string(file_name).expect("file read error");
+
+    let mut interner = StringInterner::new();
+    let mut parser = curse_parse::Parser::new(&mut interner);
 
     let ast_program = parser.parse_program(&file);
     if !parser.errors.is_empty() {
@@ -29,8 +27,11 @@ pub fn main() -> io::Result<()> {
 
     curse_interner::replace(Some(interner));
 
+    let hir_arena = Bump::new();
     let mut lowerer = curse_ast_lowering::Lowerer::new(&hir_arena);
     let hir_program = curse_ast_lowering::Lower::lower(&ast_program, &mut lowerer);
+
+    dbg!(&hir_program.struct_defs);
 
     if !lowerer.errors.is_empty() {
         eprintln!("{:?}", lowerer.errors);

--- a/compiler/curse_interpreter/src/main.rs
+++ b/compiler/curse_interpreter/src/main.rs
@@ -31,8 +31,6 @@ pub fn main() -> io::Result<()> {
     let mut lowerer = curse_ast_lowering::Lowerer::new(&hir_arena);
     let hir_program = curse_ast_lowering::Lower::lower(&ast_program, &mut lowerer);
 
-    dbg!(&hir_program.struct_defs);
-
     if !lowerer.errors.is_empty() {
         eprintln!("{:?}", lowerer.errors);
         return Ok(());

--- a/compiler/curse_interpreter/testing.curse
+++ b/compiler/curse_interpreter/testing.curse
@@ -40,6 +40,16 @@ choice Option |T| {
     None {},
 }
 
+struct Point {
+    x: I32,
+    y: I32,
+}
+
+struct Wrapper |T| {
+    value: T,
+    yes: Bool,
+}
+
 // this also parses, but like `calculate` for some reason parses to an empty
 // function
 fn map_result (


### PR DESCRIPTION
Fixed the bugs brought up in #9 that caused
1. struct definitions wrapping records, and
2. piecewise functions

to become empty after lowering.

The root of the bug was that my special `Iter` type that implements `ExactSizedIterator` implemented `Iterator::size_hint` incorrectly, and sometimes falsely would return 0. This meant that in the lowering code, `Bump::alloc_slice_fill_iter` would look at the length of the iterator and see 0, thus resulting in just `&[]`.