### PR TITLE
Fixed pattern matching on choice types

### DIFF
--- a/compiler/curse_interner/src/lib.rs
+++ b/compiler/curse_interner/src/lib.rs
@@ -17,7 +17,7 @@ pub fn init() -> Option<StringInterner> {
     replace(Some(StringInterner::new()))
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Eq, Hash)]
 pub struct Ident {
     pub symbol: InternedString,
     pub span: Span,
@@ -64,6 +64,24 @@ impl HasSpan for Ident {
 
     fn end(&self) -> u32 {
         self.span.end
+    }
+}
+
+impl PartialEq for Ident {
+    fn eq(&self, other: &Self) -> bool {
+        self.symbol == other.symbol
+    }
+}
+
+impl PartialOrd for Ident {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.symbol.partial_cmp(&other.symbol)
+    }
+}
+
+impl Ord for Ident {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.symbol.cmp(&other.symbol)
     }
 }
 

--- a/compiler/curse_interpreter/src/evaluation/mod.rs
+++ b/compiler/curse_interpreter/src/evaluation/mod.rs
@@ -4,7 +4,7 @@ use crate::builtins;
 use crate::error::EvalError;
 use crate::value::{OwnedMap, Value, ValueRef};
 use curse_hir::hir::{self, ExprKind, ExprRef, Lit, PatKind, PatRef, Program};
-use curse_interner::{Ident, InternedString};
+use curse_interner::InternedString;
 
 // globally available functions, both regular named functions as well as type constructors
 pub struct GlobalBindings<'hir> {
@@ -129,13 +129,6 @@ fn call_function<'hir>(
     }
 }
 
-fn tag_path_equal<'a>(path1: &'a [Ident], path2: &'a [Ident]) -> bool {
-    path1.len() == path2.len()
-        && path1.iter().zip(path2).fold(true, |acc, (tag1, tag2)| {
-            acc && (tag1.to_string() == tag2.to_string())
-        })
-}
-
 fn check_pattern<'hir>(value: &Value, pattern: PatRef<'hir>) -> bool {
     match (&pattern.kind, value) {
         (PatKind::Record(pattern_map), Value::Record(value_map)) => {
@@ -158,7 +151,7 @@ fn check_pattern<'hir>(value: &Value, pattern: PatRef<'hir>) -> bool {
                 value,
             },
         ) => {
-            if tag_path_equal(pat_tag, value_tag) {
+            if pat_tag == value_tag {
                 check_pattern(value, pattern)
             } else {
                 false
@@ -203,7 +196,7 @@ fn match_pattern<'hir>(
                     value,
                 },
             ) => {
-                if tag_path_equal(pat_tag, value_tag) {
+                if pat_tag == value_tag {
                     match_pattern(value.clone(), pattern, local_state)
                 } else {
                     Err(EvalError::FailedPatternMatch)

--- a/compiler/curse_interpreter/testing.curse
+++ b/compiler/curse_interpreter/testing.curse
@@ -17,7 +17,6 @@ choice IntBool {
     Boolean Bool,
 }
 
-// for some reason, this function parses as having empty arms
 fn calculate (
     |IntBool::Int n| (IntBool::Int (n + 1)),
     |IntBool::Boolean b| (IntBool::Boolean b),
@@ -50,13 +49,19 @@ struct Wrapper |T| {
     yes: Bool,
 }
 
-// this also parses, but like `calculate` for some reason parses to an empty
-// function
 fn map_result (
     |Result::Ok x, f| (Result::Ok (x in f)),
     |Result::Err e, f| (Result::Err e),
 )
 
-// we can instantiate an `IntBool`, but `calculate` doesn't work since it
-// parses as having no arms for some reason
+fn add_points |{ x: x1, y: y1 }, { x: x2, y: y2 }|
+    {
+        x: x1 + x2,
+        y: y1 + y2,
+    }
+
+// types would make this actually be `Point`s, but oh well, this works
+fn main2 || { x: 1, y: 2 } add_points { x: 3, y: 4 }
+
+// works, but doesn't parse without the parens (should it?)
 fn main || (Result::Ok 3) map_result inc

--- a/compiler/curse_interpreter/testing.curse
+++ b/compiler/curse_interpreter/testing.curse
@@ -59,4 +59,4 @@ fn map_result (
 
 // we can instantiate an `IntBool`, but `calculate` doesn't work since it
 // parses as having no arms for some reason
-fn main || fib of 10
+fn main || (Result::Ok 3) map_result inc


### PR DESCRIPTION
Fixed pattern matching on choice types by manually implementing `PartialEq`, `PartialOrd`, and `Ord` for `Ident` so that  they only check `symbol` rather than also checking `span`. Also pattern matching on structs (and using them more generally) does appear to work.