### PR TITLE
Dedup imports

### DIFF
--- a/compiler/curse_ast/src/ast/mod.rs
+++ b/compiler/curse_ast/src/ast/mod.rs
@@ -17,7 +17,7 @@ pub mod bikeshed {
         #[derive(Debug, Clone)]
         pub struct DynamicImport {
             pub dynamic_import: tok::DynamicImport,
-            pub file_string: Ident,
+            pub module: Ident,
         }
     }
 }

--- a/compiler/curse_ast_lowering/src/lowerer.rs
+++ b/compiler/curse_ast_lowering/src/lowerer.rs
@@ -118,7 +118,7 @@ impl<'hir> Lower<'hir> for ast::Program {
             dynamic_imports: self
                 .dynamic_imports
                 .iter()
-                .map(|di| di.file_string)
+                .map(|di| di.module)
                 .collect(),
         };
 

--- a/compiler/curse_interpreter/binary_tree.curse
+++ b/compiler/curse_interpreter/binary_tree.curse
@@ -1,4 +1,4 @@
-dynamic_import "std.curse"
+dynamic_import std
 
 choice Tree |T| {
     Node {

--- a/compiler/curse_interpreter/combinators.curse
+++ b/compiler/curse_interpreter/combinators.curse
@@ -1,6 +1,6 @@
 // I usually want `combinators` and `llist`, but they both import `std`, this
 // way we'll just always have both
-dynamic_import "llist.curse"
+dynamic_import llist
 
 // dyadic extensions of I combinators
 fn left |x, y| x

--- a/compiler/curse_interpreter/iter.curse
+++ b/compiler/curse_interpreter/iter.curse
@@ -1,4 +1,4 @@
-dynamic_import "std.curse"
+dynamic_import std
 
 struct Fn |Lhs * Rhs * Out| {}
 

--- a/compiler/curse_interpreter/llist.curse
+++ b/compiler/curse_interpreter/llist.curse
@@ -1,4 +1,4 @@
-dynamic_import "std.curse"
+dynamic_import std
 
 choice List {
     Cons {

--- a/compiler/curse_interpreter/project_euler/problem1.curse
+++ b/compiler/curse_interpreter/project_euler/problem1.curse
@@ -1,4 +1,4 @@
-dynamic_import "combinators.curse"
+dynamic_import combinators
 
 // built on release mode, doesn't overflow the stack and executes in about
 // 9.5ms with the right answer!

--- a/compiler/curse_interpreter/project_euler/problem2.curse
+++ b/compiler/curse_interpreter/project_euler/problem2.curse
@@ -1,4 +1,4 @@
-dynamic_import "llist.curse"
+dynamic_import llist
 
 // 0.5ms!!!!
 fn main ||

--- a/compiler/curse_interpreter/project_euler/problem3.curse
+++ b/compiler/curse_interpreter/project_euler/problem3.curse
@@ -1,4 +1,4 @@
-dynamic_import "std.curse"
+dynamic_import std
 
 fn largest_prime_factor |n|
     { i: 2, n } rec |loop| (

--- a/compiler/curse_interpreter/project_euler/problem5.curse
+++ b/compiler/curse_interpreter/project_euler/problem5.curse
@@ -1,4 +1,4 @@
-dynamic_import "llist.curse"
+dynamic_import llist
 
 // literally easiest with just a desktop calculator
 // here's a solution to demonstrate curse though

--- a/compiler/curse_interpreter/project_euler/problem6.curse
+++ b/compiler/curse_interpreter/project_euler/problem6.curse
@@ -1,4 +1,4 @@
-dynamic_import "combinators.curse"
+dynamic_import combinators
 
 // 1.5ms
 fn main ||

--- a/compiler/curse_interpreter/project_euler/problem7.curse
+++ b/compiler/curse_interpreter/project_euler/problem7.curse
@@ -1,4 +1,4 @@
-dynamic_import "llist.curse"
+dynamic_import llist
 
 // I don't want to think about implementing a sieve in curse
 

--- a/compiler/curse_interpreter/yc.curse
+++ b/compiler/curse_interpreter/yc.curse
@@ -1,4 +1,4 @@
-dynamic_import "std.curse"
+dynamic_import std
 
 fn fact |n|
     { acc: 1, n } rec |loop| (

--- a/compiler/curse_parse/src/grammar.lalrpop
+++ b/compiler/curse_parse/src/grammar.lalrpop
@@ -95,7 +95,7 @@ pub Program: Program = {
 
 // TODO(quinn): BAD BAD BAD THIS IS BASICALLY C INCLUDE
 DynamicImport: bikeshed::DynamicImport = {
-    "dynamic_import" StringLiteral => bikeshed::DynamicImport::new(<>),
+    "dynamic_import" Ident => bikeshed::DynamicImport::new(<>),
 };
 
 GenericParams: GenericParams = {


### PR DESCRIPTION
Fixes #19 

Import syntax now is `dynamic_import <module_name>`, e.g. `dynamic_import std`. I added a `ImportResolver` struct in the curse interpreter that just stores vecs of fn, struct, and choice defs, as well as a hash set of things that have been imported so it doesn't import the same file twice. It's pretty hacky right now but is definitely a step in the right direction.